### PR TITLE
make loading scripts also work from non-JCR resource providers

### DIFF
--- a/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
+++ b/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
@@ -26,10 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import javax.jcr.Binary;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
@@ -222,14 +218,13 @@ public class AecuServiceImpl implements AecuService {
      */
     private String loadScript(String path, ResourceResolver resolver) throws AecuException {
         Resource resource = resolver.getResource(path + "/" + JcrConstants.JCR_CONTENT);
-        Binary binary;
-        try {
-            binary = resource.adaptTo(Node.class).getProperty(JcrConstants.JCR_DATA).getBinary();
-            InputStream inputStream = binary.getStream();
-            String script = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
-            binary.dispose();
-            return script;
-        } catch (RepositoryException | IOException e) {
+        // https://sling.apache.org/documentation/the-sling-engine/resources.html#binary-support
+        try (InputStream inputStream = resource.adaptTo(InputStream.class)){
+            if (inputStream == null) {
+                throw new IOException("Resource at '" + path +"' cannot be adapted to InputStream, it doesn't seem to contain binary data");
+            }
+            return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        } catch (IOException e) {
             throw new AecuException("Unable to read script", e);
         }
     }

--- a/core/src/test/java/de/valtech/aecu/core/service/AecuServiceImplTest.java
+++ b/core/src/test/java/de/valtech/aecu/core/service/AecuServiceImplTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -320,10 +321,7 @@ public class AecuServiceImplTest {
         when(resource.getName()).thenReturn(FILE1);
         when(scriptContext.getScript()).thenReturn(DIR);
         ByteArrayInputStream stream = new ByteArrayInputStream("test".getBytes());
-        when(binary.getStream()).thenReturn(stream);
-        when(resource.adaptTo(Node.class)).thenReturn(node);
-        when(node.getProperty(JcrConstants.JCR_DATA)).thenReturn(property);
-        when(property.getBinary()).thenReturn(binary);
+        when(resource.adaptTo(InputStream.class)).thenReturn(stream);
 
         RunScriptResponse response = DefaultRunScriptResponse.fromResult(scriptContext, null, null, null);
         when(groovyConsoleService.runScript(Mockito.any())).thenReturn(response);


### PR DESCRIPTION
prevent leak in case of exceptions