### PR TITLE
Feature/update to groovy 4.x

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -116,8 +116,8 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/cloud.startup.hook/pom.xml
+++ b/cloud.startup.hook/pom.xml
@@ -76,8 +76,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
         </dependency>
         <dependency>
             <groupId>be.orbinson.aem</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,8 +89,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
         </dependency>
         <dependency>
             <groupId>be.orbinson.aem</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@
                         <Import-Package>
                             !antlr.*,
                             javax.annotation;version=0.0.0,
-                            be.orbinson.aem.groovy.console.*;version="[15.1,19)",
+                            be.orbinson.aem.groovy.console.*;version="[19,20)",
                             *
                         </Import-Package>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
             <dependency>
                 <groupId>be.orbinson.aem</groupId>
                 <artifactId>aem-groovy-console-api</artifactId>
-                <version>19.0.0</version>
+                <version>19.0.1</version>
                 <scope>provided</scope>
                 <!-- exclude dependencies -->
                 <exclusions>
@@ -548,7 +548,7 @@
             <dependency>
                 <groupId>be.orbinson.aem</groupId>
                 <artifactId>aem-groovy-console-all</artifactId>
-                <version>19.0.0</version>
+                <version>19.0.1</version>
                 <type>zip</type>
                 <!-- exclude dependencies -->
                 <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -527,9 +527,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>2.4.15</version>
+                <groupId>org.apache.groovy</groupId>
+                <artifactId>groovy</artifactId>
+                <version>4.0.9</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
             <dependency>
                 <groupId>be.orbinson.aem</groupId>
                 <artifactId>aem-groovy-console-api</artifactId>
-                <version>18.0.3</version>
+                <version>19.0.0</version>
                 <scope>provided</scope>
                 <!-- exclude dependencies -->
                 <exclusions>
@@ -548,7 +548,7 @@
             <dependency>
                 <groupId>be.orbinson.aem</groupId>
                 <artifactId>aem-groovy-console-all</artifactId>
-                <version>18.0.3</version>
+                <version>19.0.0</version>
                 <type>zip</type>
                 <!-- exclude dependencies -->
                 <exclusions>


### PR DESCRIPTION
This version contains the latest Groovyconsole, which works on Groovy 4.x, supporting things like java lambda's etc..