### PR TITLE
added filterByPropertyIsMultiple

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -338,6 +338,7 @@ Filters the resources by property values.
 * filterByHasProperty: matches all nodes that have the given property. The value of the property is not relevant.
 * filterByNotHasProperty: matches all nodes that do not have the given property. The value of the property is not relevant.
 * filterByProperty: matches all nodes that have the given attribute value. Filter does not match if attribute is not present. By using a value of "null" you can search if an attribute is not present.
+* filterByPropertyIsMultiple: matches all nodes where a given property is a multi-value property (such as an array or list) and contains a specific value or values. The filter does not match if the attribute does not exist, or if it exists but is not a multi-value property or does not contain the specified value or values.
 * filterByNotProperty: matches all nodes that do not have the given attribute value. Filter matches if attribute is not present.
 * filterByProperties: use this to filter by a list of property values (e.g. sling:resourceType). All properties in the map are required to to match. Filter does not match if attribute does not exist.
 * filterByNotProperties: use this to filter by a list of property values (e.g. sling:resourceType) is not matching. If any property in the map does not match the filter matches. Filter matches if attribute does not exist.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.api</artifactId>

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/ContentUpgrade.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/ContentUpgrade.java
@@ -134,6 +134,15 @@ public interface ContentUpgrade {
     ContentUpgrade filterByNotProperty(String name, Object value);
 
     /**
+     * Filters by matching a single property.
+     *
+     * @param name  property name
+     * @param value property value
+     * @return upgrade object
+     */
+    ContentUpgrade filterByPropertyIsMultiple(String name, Object value);
+
+    /**
      * Filters by matching a single property using a regular expression for the value. This is
      * intended for single value properties.
      *

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/ContentUpgrade.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/ContentUpgrade.java
@@ -138,7 +138,7 @@ public interface ContentUpgrade {
      * intended for single value properties.
      *
      * @param name  property name
-     * @param regex regular expression to match value
+     * @param value attribute value
      * @return upgrade object
      */
     ContentUpgrade filterByPropertyIsMultiple(String name, Object value);

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/ContentUpgrade.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/ContentUpgrade.java
@@ -134,10 +134,11 @@ public interface ContentUpgrade {
     ContentUpgrade filterByNotProperty(String name, Object value);
 
     /**
-     * Filters by matching a single property.
+     * Filters by matching a single property using a regular expression for the value. This is
+     * intended for single value properties.
      *
      * @param name  property name
-     * @param value property value
+     * @param regex regular expression to match value
      * @return upgrade object
      */
     ContentUpgrade filterByPropertyIsMultiple(String name, Object value);

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/FilterByPropertyIsMultiple.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/FilterByPropertyIsMultiple.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 - 2019 Valtech GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.valtech.aecu.api.groovy.console.bindings.filters;
+
+import javax.annotation.Nonnull;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+
+import de.valtech.aecu.api.groovy.console.bindings.GStringConverter;
+
+import java.util.Arrays;
+
+/**
+ * Filters resources by a given property. The filter only matches if the attribute exists and has
+ * the exact given value and the property is an array or a list.
+ *
+ * @author Roland Gruber
+ */
+public class FilterByPropertyIsMultiple implements FilterBy {
+
+    private String name;
+    private Object value;
+
+    /**
+     * Constructor
+     *
+     * @param name  attribute name
+     * @param value attribute value
+     */
+    public FilterByPropertyIsMultiple(@Nonnull String name, Object value) {
+        this.name = name;
+        this.value = GStringConverter.convert(value);
+    }
+
+    @Override
+    public boolean filter(@Nonnull Resource resource, StringBuilder output) {
+        ValueMap properties = resource.getValueMap();
+        Object attrValue = properties.get(name);
+
+        // Check if the property is an array or a list
+        if (attrValue instanceof Object[] || attrValue instanceof java.util.List) {
+            return ((value == null) && (attrValue == null)) || ((value != null) && value.equals(attrValue));
+        }
+
+        return false;
+    }
+
+
+}

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/FilterByPropertyIsMultiple.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/FilterByPropertyIsMultiple.java
@@ -25,7 +25,6 @@ import org.apache.sling.api.resource.ValueMap;
 
 import de.valtech.aecu.api.groovy.console.bindings.GStringConverter;
 
-import java.util.Arrays;
 
 /**
  * Filters resources by a given property. The filter only matches if the attribute exists and has

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/FilterByPropertyIsMultiple.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/FilterByPropertyIsMultiple.java
@@ -30,7 +30,7 @@ import de.valtech.aecu.api.groovy.console.bindings.GStringConverter;
  * Filters resources by a given property. The filter only matches if the attribute exists and has
  * the exact given value and the property is an array or a list.
  *
- * @author Roland Gruber
+ * @author Michiel Spiritus
  */
 public class FilterByPropertyIsMultiple implements FilterBy {
 

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/package-info.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/filters/package-info.java
@@ -22,7 +22,7 @@
  *
  * @author Roxana Muresan
  */
-@Version("3.2.0")
+@Version("3.3.0")
 package de.valtech.aecu.api.groovy.console.bindings.filters;
 
 import org.osgi.annotation.versioning.Version;

--- a/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/package-info.java
+++ b/api/src/main/java/de/valtech/aecu/api/groovy/console/bindings/package-info.java
@@ -22,7 +22,7 @@
  *
  * @author Roxana Muresan
  */
-@Version("4.10.0")
+@Version("4.11.0")
 package de.valtech.aecu.api.groovy.console.bindings;
 
 import org.osgi.annotation.versioning.Version;

--- a/api/src/test/java/de/valtech/aecu/core/groovy/console/bindings/filters/FilterByPropertyIsMultipleTest.java
+++ b/api/src/test/java/de/valtech/aecu/core/groovy/console/bindings/filters/FilterByPropertyIsMultipleTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Valtech GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.valtech.aecu.core.groovy.console.bindings.filters;
+
+import org.apache.sling.api.resource.ValueMap;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByPropertyIsMultiple;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests FilterByPropertyIsMultiple
+ *
+ * @author Roland Gruber
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class FilterByPropertyIsMultipleTest {
+
+    private static final String NAME = "name";
+    private static final List<String> MULTIPLE_VALUE = Arrays.asList("value1", "value2");
+
+    @Mock
+    private Resource resource;
+
+    @Mock
+    ValueMap values;
+
+    @Mock
+    ValueMap valueMap;
+
+    @BeforeEach
+    public void setup() {
+        when(resource.getValueMap()).thenReturn(values);
+    }
+
+    @Test
+    void filterAttributeArray() {
+        Object[] attrArray = new Object[]{"value1", "value2", "value3"};
+        when(resource.getValueMap()).thenReturn(valueMap);
+        when(valueMap.get("name")).thenReturn(attrArray);
+
+        FilterByPropertyIsMultiple filter = new FilterByPropertyIsMultiple("name", attrArray);
+
+        assertTrue(filter.filter(resource, new StringBuilder()));
+    }
+
+
+
+    @Test
+    public void filterAttributeList() {
+        FilterByPropertyIsMultiple filter = new FilterByPropertyIsMultiple(NAME, MULTIPLE_VALUE);
+        when(values.get(NAME)).thenReturn(MULTIPLE_VALUE);
+
+        assertTrue(filter.filter(resource, new StringBuilder()));
+    }
+
+    @Test
+    public void filterAttributeNonMultiple() {
+        FilterByPropertyIsMultiple filter = new FilterByPropertyIsMultiple(NAME, "value");
+        when(values.get(NAME)).thenReturn("value");
+
+        assertFalse(filter.filter(resource, new StringBuilder()));
+    }
+
+}

--- a/cloud.startup.hook/pom.xml
+++ b/cloud.startup.hook/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.cloud.startup.hook</artifactId>

--- a/cloud.startup.hook/pom.xml
+++ b/cloud.startup.hook/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.cloud.startup.hook</artifactId>

--- a/complete-cloud/pom.xml
+++ b/complete-cloud/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.O-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.complete.cloud</artifactId>

--- a/complete-cloud/pom.xml
+++ b/complete-cloud/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.complete.cloud</artifactId>

--- a/complete-cloud/pom.xml
+++ b/complete-cloud/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.O-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.complete.cloud</artifactId>

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.complete</artifactId>

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.complete</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.core</artifactId>

--- a/core/src/main/java/de/valtech/aecu/core/groovy/console/bindings/impl/ContentUpgradeImpl.java
+++ b/core/src/main/java/de/valtech/aecu/core/groovy/console/bindings/impl/ContentUpgradeImpl.java
@@ -50,6 +50,7 @@ import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByNodeNameRegex
 import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByPathRegex;
 import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByProperties;
 import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByProperty;
+import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByPropertyIsMultiple;
 import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByPropertyRegex;
 import de.valtech.aecu.api.groovy.console.bindings.filters.FilterByNodeRootPaths;
 import de.valtech.aecu.api.groovy.console.bindings.filters.NOTFilter;
@@ -216,6 +217,12 @@ public class ContentUpgradeImpl implements ContentUpgrade {
     @Override
     public ContentUpgrade filterByNotProperty(String name, Object value) {
         addNotFilter(new FilterByProperty(name, value));
+        return this;
+    }
+
+    @Override
+    public ContentUpgrade filterByPropertyIsMultiple(@Nonnull String name, Object value) {
+        addFilter(new FilterByPropertyIsMultiple(name, value));
         return this;
     }
 

--- a/examples-cloud/pom.xml
+++ b/examples-cloud/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.examples-cloud</artifactId>

--- a/examples-cloud/pom.xml
+++ b/examples-cloud/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.examples-cloud</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.examples</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.examples</artifactId>

--- a/oak.index/pom.xml
+++ b/oak.index/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.oak.index</artifactId>

--- a/oak.index/pom.xml
+++ b/oak.index/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.oak.index</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.valtech.aecu</groupId>
     <artifactId>aecu</artifactId>
     <packaging>pom</packaging>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.5.0-SNAPSHOT</version>
     <name>AECU</name>
     <description>AEM Easy Content Upgrade</description>
     <url>https://github.com/valtech/aem-easy-content-upgrade</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.valtech.aecu</groupId>
     <artifactId>aecu</artifactId>
     <packaging>pom</packaging>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.5.1-SNAPSHOT</version>
     <name>AECU</name>
     <description>AEM Easy Content Upgrade</description>
     <url>https://github.com/valtech/aem-easy-content-upgrade</url>
@@ -25,9 +25,9 @@
 
     <properties>
         <aem.host>localhost</aem.host>
-        <aem.port>5602</aem.port>
+        <aem.port>4502</aem.port>
         <aem.publish.host>localhost</aem.publish.host>
-        <aem.publish.port>5705</aem.publish.port>
+        <aem.publish.port>4502</aem.publish.port>
         <sling.user>admin</sling.user>
         <sling.password>admin</sling.password>
         <vault.user>admin</vault.user>
@@ -387,23 +387,6 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>8.1.2</version>
-                    <configuration>
-                        <failBuildOnCVSS>0</failBuildOnCVSS>
-                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
-                        <skipProvidedScope>true</skipProvidedScope>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -644,6 +627,12 @@
                 <artifactId>jsr305</artifactId>
                 <version>2.0.1</version>
                 <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>de.valtech.aecu</groupId>
+                <artifactId>aecu.bundle</artifactId>
+                <version>LATEST</version>
+                <type>zip</type>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.valtech.aecu</groupId>
     <artifactId>aecu</artifactId>
     <packaging>pom</packaging>
-    <version>6.5.1-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
     <name>AECU</name>
     <description>AEM Easy Content Upgrade</description>
     <url>https://github.com/valtech/aem-easy-content-upgrade</url>
@@ -25,9 +25,9 @@
 
     <properties>
         <aem.host>localhost</aem.host>
-        <aem.port>4502</aem.port>
+        <aem.port>5602</aem.port>
         <aem.publish.host>localhost</aem.publish.host>
-        <aem.publish.port>4502</aem.publish.port>
+        <aem.publish.port>5705</aem.publish.port>
         <sling.user>admin</sling.user>
         <sling.password>admin</sling.password>
         <vault.user>admin</vault.user>
@@ -387,6 +387,23 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>8.1.2</version>
+                    <configuration>
+                        <failBuildOnCVSS>0</failBuildOnCVSS>
+                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                        <skipProvidedScope>true</skipProvidedScope>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -627,12 +644,6 @@
                 <artifactId>jsr305</artifactId>
                 <version>2.0.1</version>
                 <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>de.valtech.aecu</groupId>
-                <artifactId>aecu.bundle</artifactId>
-                <version>LATEST</version>
-                <type>zip</type>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 sonar.projectKey=aecu
 # this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
 sonar.projectName=AEM Easy Content Upgrade
-sonar.projectVersion=6.4.1-SNAPSHOT
+sonar.projectVersion=6.5.1-SNAPSHOT
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 sonar.projectKey=aecu
 # this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
 sonar.projectName=AEM Easy Content Upgrade
-sonar.projectVersion=6.5.1-SNAPSHOT
+sonar.projectVersion=6.5.0-SNAPSHOT
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.ui.apps.structure</artifactId>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.ui.apps.structure</artifactId>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.ui.apps</artifactId>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.ui.apps</artifactId>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.4.1-SNAPSHOT</version>
+        <version>6.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.ui.content</artifactId>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.valtech.aecu</groupId>
         <artifactId>aecu</artifactId>
-        <version>6.5.1-SNAPSHOT</version>
+        <version>6.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aecu.ui.content</artifactId>


### PR DESCRIPTION
* filterByPropertyIsMultiple: matches all nodes where a given property is a multi-value property (such as an array or list) and contains a specific value or values. The filter does not match if the attribute does not exist, or if it exists but is not a multi-value property or does not contain the specified value or values.
