### PR TITLE
Remove property not allowed in index definition, add small section on…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -163,6 +163,10 @@ Then delete "aem-groovy-console" packages in package manager.
 
 <a name="structure"></a>
 
+## Upgrade from version lower than 5.0.0 (On Premise)
+
+The index was moved from /var/aecu to /oak:index for cloud compatibility reasons, please remove the /var/aecu/oak:index/aecuHistory to avoid duplicate index definitions
+
 # File and Folder Structure
 
 All migration scripts need to be located in:

--- a/oak.index/src/main/content/jcr_root/_oak_index/aecuHistory-custom-1/.content.xml
+++ b/oak.index/src/main/content/jcr_root/_oak_index/aecuHistory-custom-1/.content.xml
@@ -4,7 +4,6 @@
         async="async"
         compatVersion="{Long}2"
         evaluatePathRestrictions="{Boolean}true"
-        reindex="{Boolean}false"
         reindexCount="{Long}0"
         type="lucene"
         includedPaths="[/var/aecu]"


### PR DESCRIPTION
- Remove property not allowed on the index definition
- Add a small section on the readme to advice people upgrading from lower than 5.0.0 to remove the older index definition