### PR TITLE
Feature/240 java21 support

### DIFF
--- a/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuCloudStartupService.java
+++ b/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuCloudStartupService.java
@@ -97,6 +97,7 @@ public class AecuCloudStartupService {
                 Thread.sleep(1000L * WAIT_PERIOD * 2);
                 if (resourceResolver.getResource(AecuService.AECU_APPS_PATH_PREFIX) == null) {
                     LOGGER.info("AECU apps script path not found, not starting migration.");
+                    return;
                 }
                 startAecuMigration();
             } catch (InterruptedException e) {

--- a/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuCloudStartupService.java
+++ b/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuCloudStartupService.java
@@ -29,6 +29,7 @@ import java.util.List;
 import javax.jcr.Session;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.event.jobs.JobManager;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -66,6 +67,9 @@ public class AecuCloudStartupService {
     private ServiceResourceResolverService resourceResolverService;
     @Reference
     private ServiceComponentRuntime serviceComponentRuntime;
+
+    @Reference
+    private JobManager jobManager;
 
     private BundleContext bundleContext;
 
@@ -173,13 +177,7 @@ public class AecuCloudStartupService {
      * Starts the AECU migration
      */
     void startAecuMigration() {
-        try {
-            LOGGER.info("AECU migration started");
-            aecuService.executeWithInstallHookHistory(AecuService.AECU_APPS_PATH_PREFIX);
-            LOGGER.info("AECU migration finished");
-        } catch (AecuException ae) {
-            LOGGER.error("Error while executing AECU migration", ae);
-        }
+        jobManager.addJob(AecuStartupJobConsumer.JOB_TOPIC, null);
     }
 
     /**

--- a/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuCloudStartupService.java
+++ b/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuCloudStartupService.java
@@ -91,6 +91,9 @@ public class AecuCloudStartupService {
                     throw new IllegalStateException("Groovy extension services seem to be not bound");
                 }
                 Thread.sleep(1000L * WAIT_PERIOD * 2);
+                if (resourceResolver.getResource(AecuService.AECU_APPS_PATH_PREFIX) == null) {
+                    LOGGER.info("AECU apps script path not found, not starting migration.");
+                }
                 startAecuMigration();
             } catch (InterruptedException e) {
                 LOGGER.error("Interrupted", e);

--- a/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuStartupJobConsumer.java
+++ b/cloud.startup.hook/src/main/java/de/valtech/aecu/startuphook/AecuStartupJobConsumer.java
@@ -1,0 +1,41 @@
+package de.valtech.aecu.startuphook;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.valtech.aecu.api.service.AecuException;
+import de.valtech.aecu.api.service.AecuService;
+import de.valtech.aecu.api.service.HistoryEntry;
+
+import org.apache.sling.event.jobs.Job;
+import org.apache.sling.event.jobs.consumer.JobConsumer;
+
+
+@Component(service=JobConsumer.class, property= {
+    JobConsumer.PROPERTY_TOPICS + "=" + AecuStartupJobConsumer.JOB_TOPIC
+})
+public class AecuStartupJobConsumer implements JobConsumer {
+
+    protected static final String JOB_TOPIC = "de/valtech/aecu/cloud/AecuStartupJobTopic";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AecuStartupJobConsumer.class);
+    
+    @Reference
+    private AecuService aecuService;
+
+
+    public JobResult process(final Job job) {
+        try {
+            LOGGER.info("AECU migration started");
+            HistoryEntry result = aecuService.executeWithInstallHookHistory(AecuService.AECU_APPS_PATH_PREFIX);
+            LOGGER.info("AECU migration finished with result "+result.getResult());
+            return JobResult.OK;
+        } catch (AecuException ae) {
+            LOGGER.error("Error while executing AECU migration", ae);
+            // Do not retry job, hence status CANCEL (=failed permanently) and not FAILED (=can be retried)
+            return JobResult.CANCEL;
+        }
+    }
+}

--- a/cloud.startup.hook/src/test/java/de/valtech/aecu/startuphook/AecuCloudStartupServiceTest.java
+++ b/cloud.startup.hook/src/test/java/de/valtech/aecu/startuphook/AecuCloudStartupServiceTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import javax.jcr.Session;
 
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.event.jobs.JobManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,6 +72,9 @@ public class AecuCloudStartupServiceTest {
     @Mock
     private HistoryEntry historyEntry;
 
+    @Mock
+    private JobManager jobManager;
+
     @InjectMocks
     @Spy
     private AecuCloudStartupService startupService;
@@ -79,6 +83,7 @@ public class AecuCloudStartupServiceTest {
     public void setUp() throws Exception {
         when(resolverService.getAdminResourceResolver()).thenReturn(resolver);
         when(resolver.adaptTo(Session.class)).thenReturn(session);
+        when(jobManager.addJob(anyString(), any())).thenReturn(null);
         doReturn(true).when(session).hasPermission(anyString(), anyString());
         doReturn(true).when(startupService).waitForServices();
     }
@@ -89,7 +94,7 @@ public class AecuCloudStartupServiceTest {
 
         startupService.checkAndRunMigration();
 
-        verify(aecuService, times(1)).executeWithInstallHookHistory(AecuService.AECU_APPS_PATH_PREFIX);
+        verify(jobManager, times(1)).addJob(AecuStartupJobConsumer.JOB_TOPIC, null);
     }
 
     @Test
@@ -106,7 +111,7 @@ public class AecuCloudStartupServiceTest {
 
         startupService.checkAndRunMigration();
 
-        verify(aecuService, never()).executeWithInstallHookHistory(AecuService.AECU_APPS_PATH_PREFIX);
+        verify(jobManager, never()).addJob(AecuStartupJobConsumer.JOB_TOPIC, null);
     }
 
     @Test

--- a/cloud.startup.hook/src/test/java/de/valtech/aecu/startuphook/AecuCloudStartupServiceTest.java
+++ b/cloud.startup.hook/src/test/java/de/valtech/aecu/startuphook/AecuCloudStartupServiceTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import javax.jcr.Session;
 
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.event.jobs.JobManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,6 +71,10 @@ public class AecuCloudStartupServiceTest {
     private Session session;
 
     @Mock
+    private Resource resource;
+
+
+    @Mock
     private HistoryEntry historyEntry;
 
     @Mock
@@ -83,6 +88,7 @@ public class AecuCloudStartupServiceTest {
     public void setUp() throws Exception {
         when(resolverService.getAdminResourceResolver()).thenReturn(resolver);
         when(resolver.adaptTo(Session.class)).thenReturn(session);
+        when(resolver.getResource(AecuService.AECU_APPS_PATH_PREFIX)).thenReturn(resource);
         when(jobManager.addJob(anyString(), any())).thenReturn(null);
         doReturn(true).when(session).hasPermission(anyString(), anyString());
         doReturn(true).when(startupService).waitForServices();

--- a/complete-cloud/src/main/content/jcr_root/apps/valtech/aecu-complete/config/org.apache.sling.event.jobs.QueueConfiguration~aecu-startup-hook-job-consumer.xml
+++ b/complete-cloud/src/main/content/jcr_root/apps/valtech/aecu-complete/config/org.apache.sling.event.jobs.QueueConfiguration~aecu-startup-hook-job-consumer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OsgiConfig"
+
+          queue.name="AECU Cloud Startup Job Queue"
+          queue.priority="NORM"
+          queue.topics="de/valtech/aecu/cloud/AecuStartupJobTopic"
+          queue.type="ORDERED"
+          queue.keepJobs="true"
+/>

--- a/core/src/main/java/de/valtech/aecu/core/model/execute/ExecuteDataSource.java
+++ b/core/src/main/java/de/valtech/aecu/core/model/execute/ExecuteDataSource.java
@@ -68,8 +68,7 @@ public class ExecuteDataSource {
         String path = request.getParameter("searchPath");
         List<Resource> entries = new ArrayList<>();
 
-        if (path != null && StringUtils.isNotEmpty(path) && (path.startsWith(AecuService.AECU_CONF_PATH_PREFIX)
-                || path.startsWith(AecuService.AECU_VAR_PATH_PREFIX) || path.startsWith(AecuService.AECU_APPS_PATH_PREFIX))) {
+        if (path != null && StringUtils.isNotEmpty(path) ) {
             List<String> allowedScripts = aecuService.getFiles(path);
             ResourceResolver resourceResolver = request.getResourceResolver();
             for (String scriptPath : allowedScripts) {

--- a/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
+++ b/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
@@ -114,7 +114,7 @@ public class AecuServiceImpl implements AecuService {
         }
         Resource resource = resolver.getResource(path);
         if (resource == null) {
-            throw new AecuException("Path is invalid");
+            throw new AecuException("Path " + path + " is invalid");
         }
         List<String> candidates = new ArrayList<>();
         if (isFolder(resource) && matchesRunmodes(resource.getName())) {
@@ -180,10 +180,10 @@ public class AecuServiceImpl implements AecuService {
         try (ResourceResolver resolver = resolverService.getContentMigratorResourceResolver()) {
             Resource resource = resolver.getResource(path);
             if (resource == null) {
-                throw new AecuException("Path is invalid");
+                throw new AecuException("Path " + path + " invalid");
             }
             if (!isValidScriptName(resource.getName())) {
-                throw new AecuException("Invalid script name");
+                throw new AecuException("Invalid script name " + resource.getName());
             }
             return executeScript(resolver, path, data);
         } catch (LoginException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -527,13 +527,13 @@
             <dependency>
                 <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy</artifactId>
-                <version>4.0.9</version>
+                <version>4.0.22</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>be.orbinson.aem</groupId>
                 <artifactId>aem-groovy-console-api</artifactId>
-                <version>19.0.4</version>
+                <version>19.0.8</version>
                 <scope>provided</scope>
                 <!-- exclude dependencies -->
                 <exclusions>
@@ -546,7 +546,7 @@
             <dependency>
                 <groupId>be.orbinson.aem</groupId>
                 <artifactId>aem-groovy-console-all</artifactId>
-                <version>19.0.3</version>
+                <version>19.0.8</version>
                 <type>zip</type>
                 <!-- exclude dependencies -->
                 <exclusions>


### PR DESCRIPTION
- #240: upgrade groovyconsole
- #228 - Change AECU cloud startup hook to use sling job for processing scripts 
- #228 - improve logging and don't start aecu migration in case script path is not around
- #237: move limitation in ExecuteDataSource to only execute in paths for the installhooks