### PR TITLE
Add the script path to the AECU service ScriptContext

### DIFF
--- a/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
+++ b/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
@@ -23,10 +23,16 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.jcr.Session;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -210,7 +216,9 @@ public class AecuServiceImpl implements AecuService {
                         prechecksResult.getOutput(), null, path);
             }
         }
-        ScriptContext scriptContext = new AecuScriptContext(loadScript(path, resolver), resolver, data);
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", path);
+        ScriptContext scriptContext = new AecuScriptContext(loadScript(path, resolver), resolver, updateData(data, properties));
         RunScriptResponse response = groovyConsoleService.runScript(scriptContext);
         boolean success = StringUtils.isBlank(response.getExceptionStackTrace());
         if (success) {
@@ -226,6 +234,22 @@ public class AecuServiceImpl implements AecuService {
         ExecutionState state = success ? ExecutionState.SUCCESS : ExecutionState.FAILED;
         return new ExecutionResult(state, response.getRunningTime(), result,
                 response.getOutput() + response.getExceptionStackTrace(), fallbackResult, path);
+    }
+
+    /**
+     * Add properties to data
+     *
+     * @param data data
+     * @param properties properties
+     * @return updated data
+     */
+    private String updateData(String data, Map<String, String> properties) {
+        Gson gson = new Gson();
+        JsonObject dataJsonObject = data != null ? JsonParser.parseString(data).getAsJsonObject() : new JsonObject();
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            dataJsonObject.addProperty(entry.getKey(), entry.getValue());
+        }
+        return gson.toJson(dataJsonObject);
     }
 
     /**

--- a/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
+++ b/core/src/main/java/de/valtech/aecu/core/service/AecuServiceImpl.java
@@ -217,7 +217,7 @@ public class AecuServiceImpl implements AecuService {
             }
         }
         Map<String, String> properties = new HashMap<>();
-        properties.put("path", path);
+        properties.put("aecuScriptPath", path);
         ScriptContext scriptContext = new AecuScriptContext(loadScript(path, resolver), resolver, updateData(data, properties));
         RunScriptResponse response = groovyConsoleService.runScript(scriptContext);
         boolean success = StringUtils.isBlank(response.getExceptionStackTrace());


### PR DESCRIPTION
When running a script, the AecuScriptContext does not contain data about the current script file.
A small update was made so that the script file path is added to the context data.
That path can now be accessed through a binding.

Related issue: https://github.com/valtech/aem-easy-content-upgrade/issues/261